### PR TITLE
Remove non boilerplate stuff and simplify layout

### DIFF
--- a/app/index/index.njk
+++ b/app/index/index.njk
@@ -4,10 +4,12 @@
   {{ message }}
 {% endblock %}
 
-{% block mainContent %}
-<div class="govuk-grid-column-two-thirds">
-  <h1 class="govuk-heading-xl">
-    {{ message }}
-  </h1>
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      {{ message }}
+    </h1>
+  </div>
 </div>
 {% endblock %}

--- a/common/templates/includes/cookies.njk
+++ b/common/templates/includes/cookies.njk
@@ -1,5 +1,0 @@
-<div id="global-cookie-message" class="cookie-banner {% if seen_cookie_message %}cookie-banner--hide{% endif %}">
-  <div class="govuk-width-container">
-    <p class="govuk-body-s">GOV.UK Pay uses cookies to make the site simpler. <a class="govuk-link"href="https://www.payments.service.gov.uk/cookies/">Find out more about cookies</a></p>
-  </div>
-</div>

--- a/common/templates/includes/footer-support-links.njk
+++ b/common/templates/includes/footer-support-links.njk
@@ -1,6 +1,0 @@
-<nav class="footer-nav">
-  <ul>
-    <li>Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a></li>
-    <li><a href="#">Cookies</a></li>
-  </ul>
-</nav>

--- a/common/templates/layout.njk
+++ b/common/templates/layout.njk
@@ -8,16 +8,6 @@
   {% include "common/templates/includes/head.njk" %}
 {% endblock %}
 
-{% block bodyStart %}
-  {% include "common/templates/includes/cookies.njk" %}
-{% endblock %}
-
-{% block content %}
-  <div class="govuk-grid-row">
-    {% block mainContent %}{% endblock %}
-  </div>
-{% endblock %}
-
 {% block footer %}
   {{
     govukFooter({


### PR DESCRIPTION
Addressing comments from https://github.com/alphagov/gds-nodejs-boilerplate/pull/5

- Remove non boilerplate stuff
- Simplify layout and keep grid out of base layout