### PR TITLE
Watch for JavaScript changes when running with Grunt.

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -42,6 +42,14 @@ module.exports = function (grunt) {
         livereload: true
       }
     },
+    js: {
+      files: ['common/browsered/index.js'],
+      tasks: ['browserify', 'babel', 'concat'],
+      options: {
+        spawn: false,
+        livereload: true
+      }
+    },
     assets: {
       files: ['common/assets/**/*', '!common/assets/sass/**'],
       tasks: ['copy:assets'],


### PR DESCRIPTION
Partially fixes #10 for browserified scripts.

A full fix will need to deal with #13 to account for scripts in `assets/javascripts/` which the code tries to allow for.